### PR TITLE
Fix MediaRecorder event name

### DIFF
--- a/src/hooks/recorder.ts
+++ b/src/hooks/recorder.ts
@@ -57,8 +57,8 @@ export const useRecorder: () => [
             if (e instanceof BlobEvent) setAudioURL(URL.createObjectURL(e.data));
         };
 
-        recorder.addEventListener('data available', handleData);
-        return () => recorder.removeEventListener('data available', handleData);
+        recorder.addEventListener('dataavailable', handleData);
+        return () => recorder.removeEventListener('dataavailable', handleData);
     }, [recorder, isRecording]);
 
     const startRecording = () => {


### PR DESCRIPTION
## Summary
- fix the event name for MediaRecorder in the `useRecorder` hook

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68403d80edcc8329b2e9a668b0e6deec